### PR TITLE
Using context managers

### DIFF
--- a/markitdown-service/app/main.py
+++ b/markitdown-service/app/main.py
@@ -4,13 +4,12 @@ from fastapi.responses import PlainTextResponse, JSONResponse
 from pydantic import BaseModel, HttpUrl
 from typing import Optional
 from markitdown import MarkItDown
-from bs4 import BeautifulSoup
 import tempfile
 import os
 import logging
 import requests
-import re
 import time  # Add this line
+from contextlib import contextmanager
 from app.core.config import settings
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
@@ -91,6 +90,7 @@ class UrlInput(BaseModel):
     url: HttpUrl
     options: Optional[dict] = None
 
+@contextmanager
 def save_temp_file(content: bytes, suffix: str) -> str:
     """
     Save content to a temporary file and return the file path.
@@ -98,11 +98,11 @@ def save_temp_file(content: bytes, suffix: str) -> str:
     if len(content) > settings.MAX_FILE_SIZE:
         raise FileProcessingError(f"File size exceeds maximum limit of {settings.MAX_FILE_SIZE} bytes")
 
-    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+    with tempfile.NamedTemporaryFile(suffix=suffix) as temp_file:
         try:
             temp_file.write(content)
             logger.debug(f"Temporary file created at: {temp_file.name}")
-            return temp_file.name
+            yield temp_file.name
         except Exception as e:
             logger.exception("Failed to create temporary file")
             if os.path.exists(temp_file.name):
@@ -139,87 +139,11 @@ def get_rate_limit_headers(request: Request) -> dict:
         "X-RateLimit-Reset": str(getattr(request.state, "view_rate_limit_reset", 0))
     }
 
-@app.post("/convert/text", response_class=RateLimitedResponse)
-@limiter.limit(f"{settings.RATE_LIMIT_REQUESTS}/hour")
-async def convert_text(request: Request, text_input: TextInput):
-    """Convert text or HTML to markdown."""
-    temp_file_path = None
+
+@contextmanager
+def error_handler():
     try:
-        logger.debug(f"Received content: {text_input.content[:100]}...")
-        content = text_input.content
-        temp_file_path = save_temp_file(content.encode('utf-8'), suffix='.html')
-        markdown_content = process_conversion(temp_file_path, '.html')
-        headers = get_rate_limit_headers(request)
-        return RateLimitedResponse(content=markdown_content, headers=headers)
-    except FileProcessingError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except ConversionError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
-    except Exception as e:
-        logger.exception("Unexpected error during text conversion")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, 
-                          detail="An unexpected error occurred during conversion")
-    finally:
-        if temp_file_path and os.path.exists(temp_file_path):
-            os.unlink(temp_file_path)
-            logger.debug("Temporary file cleaned up")
-
-@app.post("/convert/file", response_class=RateLimitedResponse)
-@limiter.limit(f"{settings.RATE_LIMIT_REQUESTS}/hour")
-async def convert_file(request: Request, file: UploadFile = File(...)):
-    """Convert an uploaded file to markdown."""
-    temp_file_path = None
-    try:
-        _, ext = os.path.splitext(file.filename)
-        if ext.lower() not in settings.SUPPORTED_EXTENSIONS:
-            raise FileProcessingError(f"Unsupported file type: {ext}")
-
-        content = await file.read()
-        if len(content) > settings.MAX_FILE_SIZE:
-            raise FileProcessingError(f"File size exceeds maximum limit of {settings.MAX_FILE_SIZE} bytes")
-
-        temp_file_path = save_temp_file(content, suffix=ext)
-        markdown_content = process_conversion(temp_file_path, ext)
-        headers = get_rate_limit_headers(request)
-        return RateLimitedResponse(content=markdown_content, headers=headers)
-    except FileProcessingError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except ConversionError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
-    except Exception as e:
-        logger.exception("Unexpected error during file conversion")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, 
-                          detail="An unexpected error occurred during conversion")
-    finally:
-        if temp_file_path and os.path.exists(temp_file_path):
-            os.unlink(temp_file_path)
-            logger.debug("Temporary file cleaned up")
-
-@app.post("/convert/url", response_class=RateLimitedResponse)
-@limiter.limit(f"{settings.RATE_LIMIT_REQUESTS}/hour")
-async def convert_url(request: Request, url_input: UrlInput):
-    """Fetch a URL and convert its content to markdown."""
-    temp_file_path = None
-    try:
-        logger.debug(f"Fetching URL: {url_input.url}")
-        headers = {'User-Agent': settings.USER_AGENT}
-        
-        response = requests.get(
-            str(url_input.url), 
-            headers=headers, 
-            timeout=settings.REQUEST_TIMEOUT
-        )
-        response.raise_for_status()
-        
-        content = response.content
-        temp_file_path = save_temp_file(content, suffix='.html')
-        markdown_content = process_conversion(
-            temp_file_path,
-            '.html',
-            url=str(url_input.url)
-        )
-        headers = get_rate_limit_headers(request)
-        return RateLimitedResponse(content=markdown_content, headers=headers)
+        yield None
     except requests.RequestException as e:
         logger.exception("Error fetching URL")
         raise HTTPException(
@@ -231,10 +155,66 @@ async def convert_url(request: Request, url_input: UrlInput):
     except ConversionError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
     except Exception as e:
-        logger.exception("Unexpected error during URL conversion")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, 
+        logger.exception("Unexpected error during text conversion")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                           detail="An unexpected error occurred during conversion")
-    finally:
-        if temp_file_path and os.path.exists(temp_file_path):
-            os.unlink(temp_file_path)
-            logger.debug("Temporary file cleaned up")
+
+
+
+@app.post("/convert/text", response_class=RateLimitedResponse)
+@limiter.limit(f"{settings.RATE_LIMIT_REQUESTS}/hour")
+async def convert_text(request: Request, text_input: TextInput):
+    """Convert text or HTML to markdown."""
+    with error_handler():
+        logger.debug(f"Received content: {text_input.content[:100]}...")
+        content = text_input.content
+        with save_temp_file(content.encode('utf-8'), suffix='.html') as temp_file_path:
+            markdown_content = process_conversion(temp_file_path, '.html')
+            headers = get_rate_limit_headers(request)
+            return RateLimitedResponse(content=markdown_content, headers=headers)
+
+
+@app.post("/convert/file", response_class=RateLimitedResponse)
+@limiter.limit(f"{settings.RATE_LIMIT_REQUESTS}/hour")
+async def convert_file(request: Request, file: UploadFile = File(...)):
+    """Convert an uploaded file to markdown."""
+    with error_handler():
+        _, ext = os.path.splitext(file.filename)
+        if ext.lower() not in settings.SUPPORTED_EXTENSIONS:
+            raise FileProcessingError(f"Unsupported file type: {ext}")
+
+        content = await file.read()
+        if len(content) > settings.MAX_FILE_SIZE:
+            raise FileProcessingError(f"File size exceeds maximum limit of {settings.MAX_FILE_SIZE} bytes")
+
+        with save_temp_file(content, suffix=ext) as temp_file_path:
+            markdown_content = process_conversion(temp_file_path, ext)
+            headers = get_rate_limit_headers(request)
+            return RateLimitedResponse(content=markdown_content, headers=headers)
+
+
+
+@app.post("/convert/url", response_class=RateLimitedResponse)
+@limiter.limit(f"{settings.RATE_LIMIT_REQUESTS}/hour")
+async def convert_url(request: Request, url_input: UrlInput):
+    """Fetch a URL and convert its content to markdown."""
+    with error_handler():
+        logger.debug(f"Fetching URL: {url_input.url}")
+        headers = {'User-Agent': settings.USER_AGENT}
+        
+        response = requests.get(
+            str(url_input.url), 
+            headers=headers, 
+            timeout=settings.REQUEST_TIMEOUT
+        )
+        response.raise_for_status()
+        
+        content = response.content
+        with save_temp_file(content, suffix='.html') as temp_file_path:
+            markdown_content = process_conversion(
+                temp_file_path,
+                '.html',
+                url=str(url_input.url)
+            )
+            headers = get_rate_limit_headers(request)
+            return RateLimitedResponse(content=markdown_content, headers=headers)


### PR DESCRIPTION
Everything looks pretty solid! No glaring errors; you'd probably want to use a linter/formatter (pylint and black) and I like isort to sort imports automatically, but it's not necessary.

This PR implements one big change that tidies things up quite a bit, namely the use of [contextlib](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager) to enable you to create context managers (things that use `with thing() as blah:` from generators (which look like functions, but have a `yield` instead of (usually) a `return` statement.

The nice thing about this is that you can get rid of all your tempfile tracking and cleanup if you let _its_ context manager handle that, and just yield the `temp_file.name` from `save_temp_file`. Then you can get rid of all the `finally` blocks.

You could also create FastAPI error handlers for all of the different errors you're raising, but I took the simpler approach of writing another context manager which handles them all. Between these two changes, you top level handlers become a lot cleaner:

```python
@app.post("/convert/text", response_class=RateLimitedResponse)
@limiter.limit(f"{settings.RATE_LIMIT_REQUESTS}/hour")
async def convert_text(request: Request, text_input: TextInput):
    """Convert text or HTML to markdown."""
    with error_handler():
        logger.debug(f"Received content: {text_input.content[:100]}...")
        content = text_input.content
        with save_temp_file(content.encode('utf-8'), suffix='.html') as temp_file_path:
            markdown_content = process_conversion(temp_file_path, '.html')
            headers = get_rate_limit_headers(request)
            return RateLimitedResponse(content=markdown_content, headers=headers)
```